### PR TITLE
fix: change profile-based .env handling

### DIFF
--- a/env/env_test.go
+++ b/env/env_test.go
@@ -167,10 +167,10 @@ KEY3=value3
 		wantError   bool
 		setupEnv    map[string]string
 	}{
-		name:      "loadEnvFile with non-existent file - should not error",
+		name:      "profile specified but file not found - should error",
 		profile:   "nonexistent",
-		wantEnvs:  map[string]string{},
-		wantError: false,
+		wantEnvs:  nil,
+		wantError: true,
 	})
 
 	for _, tt := range tests {


### PR DESCRIPTION
This pull request improves the environment file loading logic in `env/env.go` to handle cases where a specified profile does not exist, and updates the corresponding test in `env/env_test.go` to check for this error scenario.

**Environment file loading enhancements:**

* Added a check in `Env.LoadEnvFiles` to return an error if a profile is specified but the environment file is not found in any search directory.
* Changed the directory traversal to use `slices.Reverse` for loading files from lower priority directories first, simplifying the code. [[1]](diffhunk://#diff-1e4c1fcda16b2f94c80249aa8e58bff941c8621fe28458d767fd3502c10c4f31R8) [[2]](diffhunk://#diff-1e4c1fcda16b2f94c80249aa8e58bff941c8621fe28458d767fd3502c10c4f31R40-R58)

**Test updates:**

* Modified the test case in `env/env_test.go` to expect an error when a profile is specified but no corresponding environment file exists.